### PR TITLE
docs: record the Tauri/Rust pivot, vision and learning plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ storage/
 
 #dev
 scripts/
+local/

--- a/README.md
+++ b/README.md
@@ -2,9 +2,23 @@
 
 **Plan. Execute. Improve.**
 
-A privacy-first PWA that answers one question: _"Did I actually do what I planned?"_
+A privacy-first personal app built for exactly one user. It currently answers one question: _"Did I actually do what I planned?"_
 
-No AI. No integrations. No account. Runs entirely in your browser using localStorage.
+No integrations. No account. No cloud. Runs entirely in your browser using localStorage.
+
+---
+
+> ## ⚠️ Pivoting
+>
+> As of **Jul 26, 2026** this project is migrating from Flet/Python to **Tauri + Rust**, and widening from a goal tracker to a personal system built around an encrypted **vault + journal** and an offline **intelligence engine**.
+>
+> Everything below describes the **current** Flet PWA, which still runs. It will be replaced.
+>
+> - [Vision](docs/VISION.md) — what this is becoming, and why
+> - [ADR-017 onward](docs/ADR.md) — the pivot decisions and rationale
+> - [Roadmap](docs/ROADMAP.md) — what's next, in order
+>
+> Two things below will stop being true: the PWA deployment ends with the migration, and local (never cloud) AI comes into scope — see [ADR-023](docs/ADR.md).
 
 ---
 

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -18,7 +18,9 @@ Apr 2, 2026  Nuclear rewrite: Flet PWA (everything deleted)
 Apr 7, 2026  Version 1.0: MVP with full feature set
 Apr 14, 2026 GitHub Pages deployment + CI/CD
 Apr 19, 2026 UI/UX polish pass
-Jun 7, 2026  Task List feature design (current)
+Jun 7, 2026  Task List feature design
+Jun 8, 2026  Concurrency lock (RMW hazard fix)
+Jul 26, 2026 Second pivot: Tauri + Rust, widened philosophy (current)
 ```
 
 ---
@@ -454,4 +456,313 @@ Implemented a global `asyncio.Lock()` (Mutex) at the storage layer (`storage.py`
 
 ---
 
-*Last updated: Jun 8, 2026*
+## ADR-017: The Second Pivot, Tauri and Rust
+
+**Date:** Jul 26, 2026
+**Status:** Active
+**Supersedes:** ADR-003. Amends ADR-001
+
+### Context
+
+Two separate things changed at the same time, and it's worth keeping them apart:
+
+1. A framework migration. Off Flet and Python, onto Tauri with a Rust core.
+2. A product change. The philosophy widens past *"did I do what I planned?"*
+
+They happened together so they're recorded together, but either could have happened without the other.
+
+### Decision
+
+Rewrite in Rust, ship through Tauri.
+
+On the product side, the question becomes *"does this make my day less annoying?"*. The old question survives as the planner module's job. Three larger modules join it (vault + journal, the intelligence engine, sync) and once those land the goal tracker becomes a subordinate piece. Detail in [VISION.md](./VISION.md).
+
+### Rationale
+
+Why Rust, honestly: to learn it properly from the ground up. That's a stated project goal, not a side effect (ADR-024). My background is C, so manual memory management isn't new territory, and Rust is the obvious next step rather than a leap.
+
+Why Tauri:
+- A native desktop app with an actual systems language underneath, which Flet couldn't give me
+- Tauri v2 targets mobile, so the cross-platform reach that motivated ADR-003 survives
+- Small binaries, uses the OS webview instead of shipping a browser engine
+- Direct filesystem, SQLite and keychain access, all of which the vault needs and a browser sandbox won't allow
+
+Why the philosophy widened: I've barely used the app and I still prefer paper. What it *did* turn out to be good for was analysing what I'd been doing. So rather than keep polishing a goal tracker that loses to a notebook on capture speed, move toward what software is actually better at, which is retrieval, persistence, and looking across long stretches of time.
+
+### Consequences
+
+- The Python `src/` tree, about 2900 lines, becomes reference material. The 67 passing tests document intended behaviour and should be ported to Rust rather than deleted.
+- The PWA dies. GitHub Pages deployment ends with the migration, so ADR-012 is terminal. That's a real loss of cross-device access, and it's why sync gets promoted to a headline feature in ADR-022.
+- The migration runs through eight toy projects, each producing a module the real app keeps. Specs in `local/rust-toys/`.
+- The name doesn't change for now. That's a deliberate deferral, not an oversight.
+
+---
+
+## ADR-018: Core-First Workspace Layout
+
+**Date:** Jul 26, 2026
+**Status:** Active
+
+### Context
+
+I might split this into several apps or repos later, one per device scope. My words at the time were "how hard can copy pasting and rewiring the code be right?......right?"
+
+The honest answer is that it's trivial if the core has no UI dependencies and awful if it does. The current Flet app is the proof: business logic and layout are tangled together throughout `planner.py`, all 662 lines of it, so nothing can be lifted out without a rewrite.
+
+### Decision
+
+A Cargo workspace with a core crate that has no UI in it.
+
+```
+core/     models, storage, planner logic, vault, sync. no UI deps
+tui/      ratatui frontend, consumes core
+desktop/  Tauri app, consumes core
+mobile/   later, consumes core
+```
+
+Every frontend is a consumer of `core`. `core` never knows a frontend exists.
+
+### Rationale
+
+- Reduces the future split to moving a directory rather than untangling a codebase
+- `core` becomes testable without a UI, which the Flet views never were
+- The TUI and Tauri can both exist during the transition (ADR-021) instead of one blocking the other
+- It forces honest interface design. If `core` needs to ask me something, that is a return value, not a dialog box
+
+### Consequences
+
+- A bit more ceremony up front: workspace manifests, explicit crate boundaries
+- Any UI concern that leaks into `core` is a bug to fix immediately, not a shortcut to live with
+- Toys 1 to 5 build `core` modules, toys 6 and 7 build consumers. The curriculum and the architecture are deliberately the same shape
+
+---
+
+## ADR-019: SQLite Replaces SharedPreferences
+
+**Date:** Jul 26, 2026
+**Status:** Active
+**Supersedes:** ADR-006
+
+### Context
+
+ADR-006 picked SharedPreferences (a JSON blob in localStorage) because it was the simplest thing that worked on both web and desktop in Flet. It came with known costs: a 5 to 10MB ceiling, a full blob rewrite on every change, and the read-modify-write hazard ADR-016 had to fix with a mutex.
+
+The new modules break all of those assumptions. Journals, indexed study material and encrypted secrets are neither small nor happy being rewritten wholesale.
+
+### Decision
+
+SQLite for everything, with the constraint that the data stays portable. A file I can copy, back up and move between devices.
+
+### Rationale
+
+- Real queries, which the intelligence engine needs and a JSON blob can't do
+- Partial writes and transactions, so a whole class of RMW hazard stops existing at the storage layer
+- One portable file, which is exactly the SSD-death scenario from VISION.md
+- Well proven, and a decent way to learn how databases work from underneath
+- Encrypted blobs sit in it fine, so the vault composes without a fight
+
+### Alternatives Considered
+
+JSON files. Simplest, but no queries and the same blob rewrite problem. Rejected.
+
+A hand-rolled storage engine. Genuinely tempting given the learning goal and consistent with the no-imports instinct, but rejected on scope. That effort is better spent on the vault and on sync, which are the parts nobody else can build for this project.
+
+### Consequences
+
+- Schema migrations become real migrations. The ADR-007 framework was never actually exercised
+- Sync semantics have to be decided at row level rather than blob level, which is harder but is the right problem (ADR-022)
+- The ADR-016 `asyncio.Lock` has no direct successor. SQLite transactions plus `Arc<Mutex>` cover it, and the compiler refuses the shared-mutable-state bug outright
+
+---
+
+## ADR-020: Vault Architecture
+
+**Date:** Jul 26, 2026
+**Status:** Active. Design settled, some mechanics still open
+
+### Context
+
+The vault and journal are the main thing. The scenario driving it is specific: the laptop dies, the SSD corrupts, and I lose passwords and context and spend weeks rebuilding. The vault exists so that stops being possible.
+
+### Threat model
+
+What I'm defending against, in order:
+
+1. Someone with the disk, or the backup, or the synced copy. This is the main one, because sync means encrypted data will deliberately be sitting on more than one device.
+2. Casual access to an unlocked machine. Hence auto-relock and the separate journal unlock state.
+3. Interception during device-to-device sync.
+
+Not defending against a compromised OS with a kernel-level keylogger. Out of scope for a personal app.
+
+### Decision
+
+Two independent unlock states, off one master password:
+
+```
+master password --KDF--> master key
+                            |-> journal key   (unlocks the journal)
+                            |-> secrets key   (unlocks passwords/2FA)
+```
+
+Unlocking the journal must not unlock the secrets vault. Reading yesterday's entry over lunch is a different act from opening the password store and the app should treat it that way.
+
+Rules:
+- Master password on every launch. No "remember me"
+- 2FA to change a password, not to read one. Writing is the higher bar
+- Auto-relock on a timeout
+- Everything offline. No cloud, no accounts, no recovery server
+- Browser autofill later, as its own piece of work with its own attack surface
+
+### Rationale
+
+Two keys instead of one because the two data sets have genuinely different exposure and access patterns. With one key, every casual journal read hands over full password access, which is a bad trade for a convenience I never asked for.
+
+This is also the one place where the hand-roll-by-default instinct gets overridden. Cryptographic primitives come from audited crates: Argon2 for key derivation, an AEAD like ChaCha20-Poly1305 or AES-GCM, plus something to zero memory. Rolling my own is how personal vaults get quietly broken, and a break here loses precisely the data this app exists to protect. Everything around the primitives (key hierarchy, file format, unlock flow, relock policy) is hand-built, and that's where the learning is anyway.
+
+### Open questions
+
+Offline password reset is unsolved. My sketch was that a reset sends a random number to the app on my phone, which collapses because the phone needs the vault to receive it. Options are printed recovery codes kept physically, secret sharing across devices, or accepting that a forgotten master password means the data is gone. Undecided.
+
+What the second factor physically is, with no server and no cloud. A TOTP seed stored inside the vault is circular. Probably a hardware token or a second enrolled device.
+
+### Consequences
+
+- Two unlock states means two session lifetimes to manage, on every frontend
+- Sync moves ciphertext only, and no device should ever hold a decrypted copy in transit
+- Losing the master password with no recovery path is currently total loss. Until that open question is settled the UI has to say so loudly
+
+---
+
+## ADR-021: TUI First, React Later
+
+**Date:** Jul 26, 2026
+**Status:** Active
+
+### Context
+
+Tauri needs a web frontend. I want React, partly for what it can do and partly because UI design is the break I take from technical work, and I want to learn UI/UX from scratch and design something actually mine. But that design doesn't exist yet, and waiting on it would block every backend module.
+
+### Decision
+
+Ship a TUI as the interim daily driver straight after the migration. Build the Tauri and React shell when there's a design worth building.
+
+Both consume `core` (ADR-018), so this is sequencing, not a fork.
+
+### Rationale
+
+- Unblocks the vault, journal and engine, none of which need a pretty interface to be useful
+- A TUI is quick to build, quick to use, and honest about being a tool rather than a product
+- Gets the app into actual daily use sooner, which matters given I've barely used the current one
+- Takes the pressure off the visual design. The unique UI is supposed to be the fun part, and designing it against a deadline would ruin that
+- Terminal-first fits how I work anyway, and it echoes the Oct 2025 CLI phase from ADR-002, which was enjoyable and died for lack of persistence and mobile reach. `core` solves both
+
+### Consequences
+
+- Two frontends to maintain once React lands. Acceptable, since the TUI remains useful over SSH and doubles as a permanent test harness for `core`
+- The design tokens from `constants/design.py` (ADR-010) carry over conceptually. Colours and spacing map to both a terminal palette and CSS variables
+- Mobile gets neither at first. Mobile arrives with React
+
+---
+
+## ADR-022: Offline-Only Sync
+
+**Date:** Jul 26, 2026
+**Status:** Accepted in principle. Design open, feasibility unproven
+
+### Context
+
+ADR-005 accepted no cross-device sync as the price of a zero-backend architecture. That trade doesn't hold any more. The PWA dies with the migration (ADR-017), taking the only cross-device access path with it, and the whole point of the vault is surviving the loss of one machine. Data sitting on one device isn't backed up.
+
+### Decision
+
+Device-to-device sync with no cloud at all. Not cloud-optional, not a self-hosted server, nothing I don't physically own. LAN discovery, direct transfer, or sneakernet.
+
+### Rationale
+
+Non-negotiable one in VISION.md is that it's offline. Syncing ciphertext to a rented box would quietly undo the privacy posture the whole thing is built on.
+
+Beyond that, edge compute, cybersecurity and IoT intersect precisely here, and those are the three areas I am most interested in. I may not succeed at it, and that is accepted going in. It is the highest-risk item in the project, and the reasoning is that the learning pays for itself even if the feature never ships.
+
+### Open questions
+
+- Discovery. mDNS on the LAN, manual pairing with a QR code, or both
+- Transport. what provides authenticated encryption between devices, and how devices get enrolled
+- Conflict resolution. Journal entries are append-mostly and easy. Vault entries are mutable, and last-write-wins can silently destroy a password change made on another device. CRDTs are the principled answer and a serious undertaking
+- Whether a phone with no app installed ever gets read-only access, and how, without a server
+
+### Consequences
+
+- Sync design constrains the SQLite schema (ADR-019). Per-row versioning or vector clocks are far cheaper to design in now than to retrofit
+- Scheduled last of the toy projects, because it depends on the vault, the storage layer, and real data existing first
+- If it turns out to be infeasible, the fallback is manual encrypted export and import. Worse, but it still covers the SSD-death scenario, which is the actual requirement
+
+---
+
+## ADR-023: Local AI, and Reversing "No AI"
+
+**Date:** Jul 26, 2026
+**Status:** Active. Direction set, implementation deferred
+
+### Context
+
+The README has said "No AI" since the Flet rewrite. I've now described the intelligence engine as an engine to replace LLMs from my life, while also saying we'll have local AI. That reads as a contradiction and isn't one.
+
+### Decision
+
+Local AI is in scope. Cloud AI isn't.
+
+The goal is ending my dependence on someone else's LLM service: the round trip, the account, my data leaving the device, the vendor who can change terms or disappear. The model runs on my hardware, over my data, with the network unplugged.
+
+Uses: coding help for assignments, exam prep (ISI, JAM, ISS), and reading my own journal and activity data to put a plan together.
+
+### Rationale
+
+This is consistent with the offline non-negotiable. A local model is actually *more* aligned with the privacy posture than where I am now, where using a cloud LLM means my questions leave the machine entirely.
+
+And the journal and activity data are exactly the context an external model can never have, which is the thing that would make a local one genuinely better rather than just more private.
+
+### Consequences
+
+- The README's "No AI" line is now false and has to be rewritten
+- ADR-005's privacy rationale gets stronger, not weaker. Data still never leaves the device
+- Model choice and runtime are deferred until there's a corpus worth feeding it. Building inference before there's data is backwards
+- The bigger version, a model that reads the whole device and proposes a reorganisation and automation plan, is parked. It's too much right now and I need features that actually help me first. Recorded because it's deliberate, not forgotten
+
+---
+
+## ADR-024: Learning Is a Requirement
+
+**Date:** Jul 26, 2026
+**Status:** Active
+
+### Context
+
+Most projects treat "the author learned something" as a nice side effect. Here it carries the same weight as shipping. The pivot to Rust exists substantially so that I learn Rust from the ground up, and so I can build creative solutions and modules instead of calling a billion imports.
+
+### Decision
+
+Learning value is a legitimate tiebreaker when choosing between implementations. Where both a hand-rolled module and a dependency would be reasonable, hand-roll it.
+
+The exception is cryptography. Always audited crates. Getting it wrong loses the data the app exists to protect, and hand-rolling it teaches the wrong lesson anyway.
+
+Secondary exceptions where the wheel isn't worth reinventing: SQLite, the Tauri runtime, serde, and the terminal and rendering backends.
+
+### Working method
+
+- I write the code, test it and refactor it. Assessment comes after. The reverse only happens if I say so
+- No unsolicited solutions when I'm stuck. I'll ask
+- Explain things through C, which is my strongest language and the right bridge to ownership and lifetimes
+
+### Rationale
+
+Optimising purely for shipping speed means importing something for everything and learning nothing, which leaves me with an app I don't understand well enough to maintain on my own. For a one-person personal tool that's a slow-motion failure. Optimising purely for learning means hand-rolling crypto and losing the vault. The line between the two is drawn above on purpose.
+
+### Consequences
+
+- Development is slower, deliberately
+- Every module gets a toy project first (`local/rust-toys/`), each producing code the real app keeps, so the learning detour and the migration are the same path
+- Progress is tracked in [LEARNING.md](./LEARNING.md), including which concepts I actually understand versus which ones I've merely used
+
+---
+
+*Last updated: Jul 26, 2026*

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,0 +1,117 @@
+# Learning log
+
+The migration is a vehicle for learning Rust as much as it is a rewrite. This file tracks what I am learning, in what order, and whether it has actually stuck.
+
+Toy specifications live in `local/rust-toys/`.
+
+Started 26 Jul 2026.
+
+## How I work
+
+Recorded here so that no agent reading the repository gets this backwards.
+
+I write the code, test it, and refactor it, and then I ask for an assessment. Not the other way round, unless I say otherwise.
+
+Do not hand me a solution when I am stuck. I will ask. Silence means I am still working on it.
+
+My background is C. I have written more C than anything else and it remains my favourite language, so manual memory management is not new to me. Explanations should route through C rather than through Python or Java: ownership is a considerably easier sell to someone who has already been tracking lifetimes by hand.
+
+## C to Rust
+
+The differences likely to catch me out.
+
+| C habit | Rust equivalent | The catch |
+|---|---|---|
+| `malloc` / `free` | Ownership and `Drop` | Freeing is automatic and happens exactly once, checked at compile time. You never call it |
+| Passing a pointer | `&T` / `&mut T` | Many shared references or one exclusive reference, never both at once |
+| `char *` | `String` vs `&str` | An owned heap buffer versus a borrowed view into someone else's. `String` is the one you would have had to free |
+| Struct assignment copies | Move semantics | Assigning a non-`Copy` value invalidates the original. The largest single surprise coming from C |
+| `void *` with a tagged union | `enum` carrying data | Variants hold payloads, and `match` is exhaustive, so the compiler catches the case I forgot |
+| `return -1` and `errno` | `Result<T, E>` and `?` | Errors appear in the signature. Ignoring one is a compiler warning rather than a silent bug months later |
+| `static` globals | `Arc<Mutex<T>>` | Shared mutable state has to prove it is thread-safe. `Send` and `Sync` are checked, not assumed |
+| Manual reference counting | `Rc` / `Arc` | Not to be reached for until plain ownership has genuinely failed. See toy 3 |
+| Pointer-based trees and lists | Arena plus index IDs | The ordinary C tree with parent pointers does not port. Toy 3 is entirely about this |
+
+The last row is the one that will hurt. In C, a tree with parent pointers is unremarkable. In Rust it fights back at every step. Toy 3 exists so that I meet that early, on my own data model, rather than three weeks into the migration.
+
+## Curriculum
+
+Eight toys, each producing something the real app keeps. Full specifications in `local/rust-toys/`.
+
+| # | Toy | Concepts | Becomes |
+|---|---|---|---|
+| 1 | Task list CLI, std only | Ownership, borrowing, structs, enums, `Vec`, `Option`, `match` | `core::model` |
+| 2 | Persistence and errors | Traits, `Result`, `?`, custom errors, serde, file I/O | `core::store` |
+| 3 | Hierarchy and cascade | The borrow checker, properly | `core::planner` |
+| 4 | Concurrency and locking | `Arc`, `Mutex`, `Send`/`Sync`, async | Storage locking |
+| 5 | Vault and crypto | Bytes, `Drop`, zeroing, KDF, AEAD | `core::vault` |
+| 6 | TUI | Event loops, render state | The interim app |
+| 7 | Tauri bridge and React | Commands, `State`, IPC | The shell |
+| 8 | Sync spike | Networking, conflict resolution | Sync, possibly |
+
+Toys 3 and 5 are the ones that matter. Toy 3 is where Rust stops being C with better syntax. Toy 5 is where the actual reason for the pivot gets built. If only two get done properly, those are the two.
+
+## Concept tracker
+
+To be marked honestly. Having used something is not the same as understanding it. The bar for a tick is being able to explain why it works, out loud, without looking it up.
+
+Legend: unmarked is untouched, `~` is used but not understood, `x` is can explain it cold.
+
+### Fundamentals
+- [ ] Ownership and moves
+- [ ] Borrowing, `&` versus `&mut`
+- [ ] One mutable reference or many immutable ones
+- [ ] `String` versus `&str`, `Vec<T>` versus `&[T]`
+- [ ] `Copy` versus `Clone`, and noticing when I clone purely to silence the compiler
+- [ ] Structs, `impl`, methods versus associated functions
+- [ ] Enums carrying data, exhaustive `match`
+- [ ] `Option<T>`, and not missing null
+
+### Intermediate
+- [ ] Traits, trait bounds, `impl Trait`
+- [ ] `Result`, `?`, custom error enums, `From`
+- [ ] Lifetimes: reading them first, writing them later
+- [ ] Iterators and closures
+- [ ] `HashMap` and the entry API
+- [ ] Modules, crates, workspaces
+- [ ] Generics
+
+### Hard parts
+- [ ] `Box`, `Rc`, `RefCell`, and when each is actually correct
+- [ ] Interior mutability and why it exists
+- [ ] Why parent pointers hurt, and the arena pattern
+- [ ] `Arc<Mutex<T>>`, `Send` and `Sync`
+- [ ] Async, futures, and the runtime
+- [ ] Deadlocking by holding a lock across an await
+- [ ] `unsafe`, and what it does not switch off
+
+### Applied
+- [ ] Serde derive and hand-written implementations
+- [ ] SQLite from Rust
+- [ ] Byte handling: `[u8; 32]`, slices, endianness, file formats
+- [ ] Crypto hygiene: KDF parameters, nonces, zeroing, constant-time comparison
+- [ ] Tauri commands and `State`
+- [ ] Cross-compilation and mobile targets
+
+## Reference
+
+The Rust Book, chapters 4 (ownership), 6 (enums and matching), 8 (collections), 9 (errors), 10 (generics, traits, lifetimes), 13 (iterators and closures), 15 (smart pointers), 16 (concurrency). Numbering past chapter 16 shifts between editions, so go by name.
+
+Rust by Example for when the Book is too wordy and I only want the shape of the syntax. Rustlings for the fundamentals block above. The Tauri v2 guide, but not until toy 7 starts.
+
+`cargo clippy` is effectively a free code review, and most of what it reports is teaching me idiom rather than catching bugs.
+
+## Log
+
+One entry per session, kept short. The useful column is what confused me; that is the part worth having later.
+
+```
+### date, toy N
+Built:
+Fought with:
+Clicked:
+Still unclear:
+Clones added purely to satisfy the compiler:
+```
+
+No entries yet. The first lands with toy 1.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,33 +1,87 @@
-# Stride — Feature Roadmap & To-Dos
+# Roadmap
 
-> Philosophy: *"Did I do everything that I planned? If not, how productive was my day?"*
+*"Does this reduce the friction in my day?"* replaced *"did I do everything I planned?"* on 26 Jul 2026 (ADR-017). Background in [VISION.md](./VISION.md).
 
----
+One module at a time. The long-term vision does not block the next useful feature.
 
-## Highest Priority
+Reorganised 26 Jul 2026 for the Tauri pivot.
 
-- [x] **Priority List (DMN Rescue List)** — A personal priority queue of the next N immediate tasks. When encountering time-wasting friction, pull index 0 and start solving/learning. Completed items flow to analytics.
-- [ ] **Concurrency / RMW Hazard Fix** — Separate modular functions for each component of a goal, OR implement a global `asyncio.Lock()` temporary state queue to prevent rapid-click race conditions and database overwrites. *(Code implemented experimentally, requires your review/optimization)*
-- [ ] **Cross-Device Sync (No Signup)** — Sync data across devices without registration. *(Design TBD)*
+## Phase 0: before anything breaks
 
----
+- [ ] Export whatever is in the deployed PWA's localStorage. Once Pages goes, it is gone.
+- [ ] Read the codebase end to end. The Python is the specification for the Rust.
+- [ ] Close out the current branch. Four `page.run_task` calls still sit outside the storage lock: [task_list_analytics.py:268](../src/views/task_list_analytics.py#L268), [:277](../src/views/task_list_analytics.py#L277), [:298](../src/views/task_list_analytics.py#L298), [analytics.py:446](../src/views/analytics.py#L446). Three are reads; `:277` is a write. Skippable if Flet is being abandoned immediately, but the branch name claims this work is finished and it is not.
 
-## Tier 1: Core Usability Improvements
+## Phase 1: learn the language
 
-- [ ] **Recurring Tasks** — Tasks that auto-schedule on a recurring basis (daily, weekly, etc.)
-- [ ] **Variable Task Duration** — Editable duration per task, visual time-block representation
-- [ ] **Conflict Detection** — Prevent double-booking time slots, visual feedback on overlap
-- [ ] **Week View** — Expand from flat list to a full week calendar view
+Specs in `local/rust-toys/`. Each toy leaves behind a module the real app keeps.
 
-## Tier 2: Integration & Intelligence
+- [ ] Toy 1, task list CLI, std only. Becomes `core::model`
+- [ ] Toy 2, persistence and error handling. Becomes `core::store`
+- [ ] Toy 3, hierarchy and cascading completion. Becomes `core::planner`. The hard one
+- [ ] Toy 4, concurrency and locking. Becomes the storage locking
+- [ ] Toy 5, vault and crypto. Becomes `core::vault`. The important one
 
-- [ ] **"Big Rock" Prioritization** — Visual distinction for high-priority/MIT items
-- [ ] **Automatic Rescheduling Assistant** — Find next available slot for missed tasks
-- [ ] **Focus Mode Integration** — Auto-trigger focus mode when scheduled task begins
-- [x] **Time Analytics Dashboard** *(partial)* — Completion rate, on-time %, same-day % exist. Missing: planned vs actual *time*, most productive day.
+## Phase 2: migrate
 
-## Tier 3: Advanced & "Blue Sky"
+- [ ] Cargo workspace with a UI-free `core` crate (ADR-018)
+- [ ] SQLite schema and migrations (ADR-019)
+- [ ] Port the goal, task and subtask hierarchy and the cascade (ADR-004, ADR-011)
+- [ ] Port the priority list (ADR-015)
+- [ ] Port the 67 Python tests. They are the behavioural specification
+- [ ] Toy 6, the TUI (ADR-021)
 
-- [ ] **Goal-Based Scheduling** — Associate tasks with long-term goals, proportional time allocation
-- [ ] **Energy Level Scheduling** — Tag tasks by energy requirement, suggest optimal placement
-- [ ] **AI-Powered Scheduling Suggestions** — ML-based habit analysis and auto-schedule drafts
+The migration is complete when the TUI has replaced the PWA in daily use, not when it compiles.
+
+## Phase 3: the main thing
+
+- [ ] Vault: master password, key hierarchy, two unlock states (ADR-020)
+- [ ] Journal: entries, retrieval, search
+- [ ] Secrets: password storage, 2FA on writes
+- [ ] Auto-relock on timeout
+
+## Phase 4: reach
+
+- [ ] Toy 7, Tauri shell
+- [ ] React frontend, once there is a design worth building (ADR-021)
+- [ ] Mobile: journal reading and vault access
+- [ ] Toy 8, sync spike (ADR-022). The highest-risk item in the project
+
+## Phase 5: the engine
+
+- [ ] Capture and index study material
+- [ ] Resource context: which textbook, and how far into it I am
+- [ ] Triggers and reminders attached to material rather than dates
+- [ ] Dead-time rescue: given ten idle minutes, what to open
+- [ ] Exam preparation tracked across months (ISI, JAM, ISS)
+- [ ] Local AI over journal and activity data (ADR-023)
+- [ ] Browser autofill
+
+## Deferred
+
+Set aside deliberately. Reasoning in [VISION.md](./VISION.md).
+
+- Local AI that reads the whole device and proposes a reorganisation plan. Too much for now
+- Offline password reset. Genuinely unsolved (ADR-020)
+- Splitting into separate apps and repositories per device. Cheap later, provided ADR-018 holds
+- Renaming. After the modules exist, not before
+
+## Carried over from the Flet era
+
+Still wanted, but each gets re-judged against the new philosophy rather than implemented on the strength of being on an old list (ADR-014).
+
+- [ ] Recurring tasks
+- [ ] Variable task duration and time blocks
+- [ ] Week view
+- [ ] Big-rock prioritisation
+- [ ] Automatic rescheduling for missed tasks
+- [ ] Focus mode integration
+- [ ] Energy-level scheduling
+- [x] Priority list / DMN rescue. Shipped in Flet, and generalises into the engine's dead-time rescue
+- [x] Concurrency fix. Shipped in Flet, and most of the problem stops existing under SQLite and Rust
+- [ ] Time analytics. Completion, on-time and same-day exist. Planned versus actual *time*, and most productive day, do not
+
+## Dead
+
+- PWA and GitHub Pages deployment. Ends with the migration (ADR-017). Sync replaces it as the cross-device story
+- `views/analytics.py`. 506 lines, fully built, never wired up (ADR-013). Port the metrics, not the view code

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,0 +1,124 @@
+# Vision
+
+Written for future me, for whatever SLM or coding agent I point at this repo, and for anyone who ends up reading it.
+
+This is the honest account rather than a pitch: what I want the app to become, what I actually use today, and which parts I already know are beyond what I can build soon. Read it before touching architecture.
+
+Written 26 Jul 2026, at the start of the second pivot.
+
+## Purpose
+
+The app used to answer one question: *"did I actually do what I planned?"*
+
+It now answers a broader one: *"does this reduce the friction in my day?"*
+
+The original question still matters, but it belongs to a single module rather than to the whole app. This has stopped being a goal tracker that happens to be personal and become a personal system that contains a goal tracker.
+
+## Current state, honestly
+
+I have barely used the app. I still prefer paper.
+
+That is worth recording because it is the most useful piece of evidence I have. Paper wins on capture speed, and nothing I build is going to beat a notebook for getting a thought out of my head. What the app did give me was a way to review what I had been doing across a week, which paper handles badly.
+
+The conclusion I draw: build for retrieval, recall, analysis, and persistence across devices and years. A feature whose value proposition amounts to "the same as writing it down, but on a screen" will not survive contact with my actual habits.
+
+## Modules
+
+In rough order of how much I need them.
+
+### Vault and journal
+
+This is the reason for the pivot.
+
+The failure I am designing against is specific: the laptop dies, the SSD corrupts, and I lose my passwords, my notes, and the accumulated context of whatever I was working on. Rebuilding that costs weeks. The vault exists to make it impossible.
+
+It holds passwords, so they exist on more than one device, and it holds the journal, so I can read it from my phone without opening a laptop.
+
+Decisions already made:
+
+- Journal and secrets unlock independently. Reading a journal entry must not expose the password vault.
+- Master password on every launch. No persistent session.
+- 2FA required to change a password. Reading is a lower bar than writing.
+- Browser autofill, eventually.
+- Offline. Not cloud-optional; no cloud.
+
+Crypto design is in ADR-020. `local/rust-toys/05-vault-and-crypto.md` builds up to it.
+
+### Intelligence engine
+
+LogSeq and Obsidian, but better suited to me. The least defined module here and the one I want most.
+
+The problem it solves is that I have more material to get through than I can hold in my head: textbooks, practice sets, exam preparation. That load currently lives in my memory, and holding it there is the actual headache.
+
+What it has to do is take information out of my head and hand it back at the right moment. Triggers and reminders attached to material rather than to dates. Retained context for a specific resource: which textbook, how far into it I am, what I was doing with it.
+
+It also has to make dead time useful. This generalises the DMN rescue list from ADR-015: given ten idle minutes, the engine should tell me what to open and where I left off, so that time goes into upskilling rather than drifting.
+
+### Planner
+
+The existing goal, task and subtask hierarchy, the priority list, and the analytics. All of it survives the migration, but none of it is the headline any more. It becomes the execution layer that the engine feeds.
+
+### Sync
+
+Every module above is worth much less if it is confined to one machine. Sync is what turns the vault into a genuine backup and makes the journal readable from my phone.
+
+The constraint is that it stays completely offline: LAN, device to device, or sneakernet, but never a server I do not own.
+
+I may not succeed at this. I intend to attempt it regardless. Edge compute, cybersecurity and IoT intersect precisely here, and those are the three areas I am most interested in, so the attempt pays for itself even if the feature does not ship.
+
+## On "replacing LLMs from my life"
+
+I have said that, and I have also said the app will have local AI. Those are not in conflict.
+
+What I want to end is my dependence on someone else's LLM service: the round trip, the account, my data leaving the machine, and the fact that it stops working when I am offline or when a company changes its terms. I am not opposed to AI.
+
+Local AI is in scope, for coding assistance on assignments, for exam preparation, and for reading my own journal and activity data to produce a plan. The distinction that matters is that the model runs on my hardware, over my data, with the network disconnected.
+
+The README still states "No AI". That is now inaccurate and needs correcting. Recorded as ADR-023.
+
+## Non-negotiables
+
+A feature that violates one of these does not get built.
+
+1. Offline. No cloud, no servers, no accounts. It has to work when the network does not.
+2. Portable data. I can pick the file up and move it. Data I cannot move is not backed up.
+3. Personal-first. Features reflect my needs, not those of a hypothetical user. There is no user base. (ADR-001, still in force.)
+4. Learning counts. A substantial part of the point is learning Rust properly, so hand-rolled beats imported unless there is a safety reason. (ADR-024.)
+5. Small steps, big goals. One module at a time. The long-term vision does not get to block the next useful feature.
+
+## Deferred
+
+Ideas I have raised, considered, and consciously set aside. Recorded so that neither I nor anyone else mistakes them for oversights.
+
+Local AI that reads the entire device and proposes a reorganisation and automation plan. My assessment at the time was that it is too much for now and that I need features that actually help me first. I still think that is correct.
+
+Offline password reset. I sketched a scheme where a reset sends a random number to the app on my phone, then realised the phone needs the vault in order to receive it, so the loop does not close. Genuinely unsolved; see ADR-020.
+
+Splitting into separate apps and repositories per device. My own comment was "how hard can copy pasting and rewiring the code be right?......right?" The answer is that it is hard when the code is tangled and trivial when the core is a crate with no UI in it, which is why ADR-018 exists.
+
+Renaming the app. Stride stays unless something better appears, and that conversation happens after the modules exist rather than before.
+
+## Device scopes
+
+One app for now, with scope varying by device. Desktop gets everything and is the migration target. Mobile gets journal reading, vault access and quick capture, and comes later.
+
+Splitting into separate projects remains on the table.
+
+## Open questions
+
+None of these are blocking yet.
+
+1. Vault recovery. What happens when I forget the master password? Printed recovery codes kept physically, Shamir shares across devices, or accepting that the data is gone.
+2. Sync conflicts. Last-write-wins or CRDTs. Journal entries are append-mostly and straightforward; vault entries are mutable and are not.
+3. What "better than Obsidian" actually means. At present it is a feeling rather than a specification, and it needs to become a list of behaviours before the engine can be built.
+4. Which local model, and how it runs. Deferred until there is data worth feeding it.
+5. The name. Deferred by decision. Candidates if I do change it: Ledger, Cairn, Anchor, Keep.
+6. What the second factor is, given no server and no cloud. A TOTP seed stored inside the vault is circular, so it is likely a hardware token or a second enrolled device.
+
+## The rest of the docs
+
+- [ADR.md](./ADR.md) — every decision and its rationale, Flask through to Tauri. Start at ADR-017 for the current pivot.
+- [LEARNING.md](./LEARNING.md) — the Rust plan and what has actually sunk in.
+- [ROADMAP.md](./ROADMAP.md) — what comes next, in order.
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — describes the current Flet app until the migration lands.
+- `local/rust-toys/` — eight toy specs that build the migration piece by piece. Untracked.


### PR DESCRIPTION
Second pivot: off Flet/Python onto Tauri with a Rust core, and a widened philosophy. The goal tracker becomes subordinate to a vault plus journal, an intelligence engine, and offline sync.

- VISION.md: purpose, modules, non-negotiables, deferred ideas and open questions. Written as the honest account rather than a pitch, including the fact that paper still wins on capture.
- ADR-017..024: the pivot itself, core-first workspace layout, SQLite replacing SharedPreferences, vault architecture and threat model, TUI before React, offline-only sync, local AI reversing "No AI", and learning as a first-class requirement.
- LEARNING.md: C-to-Rust notes, curriculum and concept tracker.
- ROADMAP.md: reorganised into phases 0-5 for the migration.
- README: pivot notice, and the inaccurate "No AI" line corrected.

Docs only, no code changes. Toy project specs live in local/, which is untracked.